### PR TITLE
Implementation socket receive timeout

### DIFF
--- a/clickhouse/base/socket.cpp
+++ b/clickhouse/base/socket.cpp
@@ -1,6 +1,7 @@
 #include "socket.h"
 #include "singleton.h"
 
+#include <chrono>
 #include <assert.h>
 #include <stdexcept>
 #include <system_error>
@@ -221,7 +222,7 @@ NetrworkInitializer::NetrworkInitializer() {
 }
 
 
-SOCKET SocketConnect(const NetworkAddress& addr) {
+SOCKET SocketConnect(const NetworkAddress& addr, std::chrono::seconds socketReceiveTimeout) {
     for (auto res = addr.Info(); res != nullptr; res = res->ai_next) {
         SOCKET s(socket(res->ai_family, res->ai_socktype, res->ai_protocol));
 
@@ -230,6 +231,10 @@ SOCKET SocketConnect(const NetworkAddress& addr) {
         }
 
         SetNonBlock(s, true);
+
+        /* Timeout in seconds */
+        timeval tv{socketReceiveTimeout.count(), 0};
+        setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, &tv , sizeof(tv));
 
         if (connect(s, res->ai_addr, (int)res->ai_addrlen) != 0) {
             int err = errno;

--- a/clickhouse/base/socket.h
+++ b/clickhouse/base/socket.h
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <string>
+#include <chrono>
 
 #if defined(_win_)
 #   pragma comment(lib, "Ws2_32.lib")
@@ -98,7 +99,7 @@ static struct NetrworkInitializer {
 } gNetrworkInitializer;
 
 ///
-SOCKET SocketConnect(const NetworkAddress& addr);
+SOCKET SocketConnect(const NetworkAddress& addr, std::chrono::seconds socketReceiveTimeout);
 
 ssize_t Poll(struct pollfd* fds, int nfds, int timeout) noexcept;
 

--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -267,7 +267,7 @@ void Client::Impl::Ping() {
 }
 
 void Client::Impl::ResetConnection() {
-    SocketHolder s(SocketConnect(NetworkAddress(options_.host, std::to_string(options_.port))));
+    SocketHolder s(SocketConnect(NetworkAddress(options_.host, std::to_string(options_.port)), options_.socket_receive_timeout));
 
     if (s.Closed()) {
         throw std::system_error(errno, std::system_category());

--- a/clickhouse/client.h
+++ b/clickhouse/client.h
@@ -56,6 +56,9 @@ struct ClientOptions {
     DECLARE_FIELD(send_retries, int, SetSendRetries, 1);
     /// Amount of time to wait before next retry.
     DECLARE_FIELD(retry_timeout, std::chrono::seconds, SetRetryTimeout, std::chrono::seconds(5));
+    /// Amount of time the socket waits for response.
+    /// If the timeout is set to zero (the default) then the operation will never timeout.
+    DECLARE_FIELD(socket_receive_timeout, std::chrono::seconds, SetSocketReceiveTimeout, std::chrono::seconds(0));
 
     /// Compression method.
     DECLARE_FIELD(compression_method, CompressionMethod, SetCompressionMethod, CompressionMethod::None);


### PR DESCRIPTION
Case: When we block the port, while the client is trying to insert the rows, there is no error, due to the TCP’s retransmission mechanism - the network stack retransmits the packets.

My solution specify the receiving or sending timeouts until reporting an error.